### PR TITLE
Making the correct usage of LIKE expressions and placeholders explicit

### DIFF
--- a/en/reference/dql-doctrine-query-language.rst
+++ b/en/reference/dql-doctrine-query-language.rst
@@ -317,7 +317,8 @@ Restricting a JOIN clause by additional conditions:
 .. code-block:: php
 
     <?php
-    $query = $em->createQuery("SELECT u FROM CmsUser u LEFT JOIN u.articles a WITH a.topic LIKE '%foo%'");
+    $query = $em->createQuery("SELECT u FROM CmsUser u LEFT JOIN u.articles a WITH a.topic LIKE :foo");
+    $query->setParameter('foo', '%foo%');
     $users = $query->getResult();
 
 Using several Fetch JOINs:


### PR DESCRIPTION
This is simply to avoid some confusion that affects newbies when working with the LIKE expression
