### PR TITLE
Add a missing section in the Configuration manual

### DIFF
--- a/en/reference/configuration.rst
+++ b/en/reference/configuration.rst
@@ -120,6 +120,13 @@ setup methods:
     $paths = array("/path/to/entities-or-mapping-files");
     $isDevMode = false;
 
+    $dbParams = array(
+        'driver'   => 'pdo_mysql',
+        'user'     => 'root',
+        'password' => '',
+        'dbname'   => 'foo',
+    );
+
     $config = Setup::createAnnotationMetadataConfiguration($paths, $isDevMode);
     $em = EntityManager::create($dbParams, $config);
 


### PR DESCRIPTION
Hi, 

I added `$dbParams` which was used but didn't exist. 
