### PR TITLE
added missing JoinColumn node for xml and yaml for many-to-one unidirect...

### DIFF
--- a/en/reference/association-mapping.rst
+++ b/en/reference/association-mapping.rst
@@ -359,7 +359,9 @@ with the following:
 
         <doctrine-mapping>
             <entity name="User">
-                <many-to-one field="address" target-entity="Address" />
+                <many-to-one field="address" target-entity="Address">
+                    <join-column name="address_id" referenced-column-name="id" />
+                </many-to-one>
             </entity>
         </doctrine-mapping>
 
@@ -370,6 +372,9 @@ with the following:
           manyToOne:
             address:
               targetEntity: Address
+              joinColumn:
+                name: address_id
+                referencedColumnName: id
 
 
 .. note::


### PR DESCRIPTION
...ional mapping

JoinColumn is referenced is a note below, but only refers to the annotation syntax - this provides the full syntax for the XML and YAML variants.
