### PR TITLE
Remove "before the lists of scheduled changes are cleared"

### DIFF
--- a/en/reference/events.rst
+++ b/en/reference/events.rst
@@ -511,8 +511,7 @@ The following restrictions apply to the onFlush event:
 postFlush
 ~~~~~~~~~
 
-``postFlush`` is called at the end of ``EntityManager#flush()`` before the 
-lists of scheduled changes are cleared. ``EntityManager#flush()`` can be 
+``postFlush`` is called at the end of ``EntityManager#flush()``. ``EntityManager#flush()`` can be 
 called safely inside its listeners.
 
 .. code-block:: php


### PR DESCRIPTION
It is not true, see https://github.com/doctrine/orm-documentation/pull/107#issuecomment-7976921 (#107)
