### PR TITLE
[Association-Mapping] - Missing many-to-many xml target-entity tag

### DIFF
--- a/en/reference/association-mapping.rst
+++ b/en/reference/association-mapping.rst
@@ -706,7 +706,7 @@ one is bidirectional.
 
         <doctrine-mapping>
             <entity name="User">
-                <many-to-many field="groups" inversed-by="users">
+                <many-to-many field="groups" inversed-by="users" target-entity="Group">
                     <join-table name="users_groups">
                         <join-columns>
                             <join-column name="user_id" referenced-column-name="id" />
@@ -719,7 +719,7 @@ one is bidirectional.
             </entity>
 
             <entity name="Group">
-                <many-to-many field="users" mapped-by="groups" />
+                <many-to-many field="users" mapped-by="groups" target-entity="User"/>
             </entity>
         </doctrine-mapping>
 


### PR DESCRIPTION
In the many to many bidirectional xml format the "target-entity" tag is missing and generates a MappingException when not included.
