### PR TITLE
Update incorrect example for DISTINCT

### DIFF
--- a/en/reference/dql-doctrine-query-language.rst
+++ b/en/reference/dql-doctrine-query-language.rst
@@ -293,7 +293,7 @@ With COUNT DISTINCT:
 
     <?php
     $query = $em->createQuery('SELECT COUNT(DISTINCT u.name) FROM CmsUser');
-    $users = $query->getResult(); // array of ForumUser objects
+    $count = $query->getResult(); // number of distinct usernames
 
 With Arithmetic Expression in WHERE clause:
 


### PR DESCRIPTION
We dont get an array of CMSUsers back from a COUNT(DISTINCT u.name) select query.