### PR TITLE
Minor docblock correction

### DIFF
--- a/en/reference/native-sql.rst
+++ b/en/reference/native-sql.rst
@@ -120,7 +120,7 @@ the method signature in detail:
      * @param string $class The class name of the joined entity.
      * @param string $alias The unique alias to use for the joined entity.
      * @param string $parentAlias The alias of the entity result that is the parent of this joined result.
-     * @param object $relation The association field that connects the parent entity result with the joined entity result.
+     * @param string $relation The association field that connects the parent entity result with the joined entity result.
      */
     public function addJoinedEntityResult($class, $alias, $parentAlias, $relation)
 


### PR DESCRIPTION
The docblock for ResultSetMappingBuilder::addJoinedEntityResult() was updated in https://github.com/doctrine/doctrine2/commit/5481e0fb8b9be48b24810232541e98b962cbf77e but the change wasn't reflected in the docs.